### PR TITLE
Utilize @FeignClient instead of RestTemplate

### DIFF
--- a/fortune-teller-ui/pom.xml
+++ b/fortune-teller-ui/pom.xml
@@ -43,6 +43,10 @@
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-netflix-hystrix-amqp</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-feign</artifactId>
+        </dependency>
     </dependencies>
 
 </project>

--- a/fortune-teller-ui/src/main/java/io/spring/cloud/samples/fortuneteller/ui/Application.java
+++ b/fortune-teller-ui/src/main/java/io/spring/cloud/samples/fortuneteller/ui/Application.java
@@ -4,10 +4,12 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.client.circuitbreaker.EnableCircuitBreaker;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+import org.springframework.cloud.netflix.feign.EnableFeignClients;
 
 @SpringBootApplication
 @EnableDiscoveryClient
 @EnableCircuitBreaker
+@EnableFeignClients
 public class Application {
 
     public static void main(String[] args) {

--- a/fortune-teller-ui/src/main/java/io/spring/cloud/samples/fortuneteller/ui/services/fortunes/FortuneService.java
+++ b/fortune-teller-ui/src/main/java/io/spring/cloud/samples/fortuneteller/ui/services/fortunes/FortuneService.java
@@ -4,7 +4,6 @@ import com.netflix.hystrix.contrib.javanica.annotation.HystrixCommand;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.stereotype.Service;
-import org.springframework.web.client.RestTemplate;
 
 @Service
 @EnableConfigurationProperties(FortuneProperties.class)
@@ -14,11 +13,11 @@ public class FortuneService {
     FortuneProperties fortuneProperties;
 
     @Autowired
-    RestTemplate restTemplate;
+    FortunesClient fortunesClient;
 
     @HystrixCommand(fallbackMethod = "fallbackFortune")
     public Fortune randomFortune() {
-        return restTemplate.getForObject("http://fortunes/random", Fortune.class);
+        return fortunesClient.randomFortune();
     }
 
     private Fortune fallbackFortune() {

--- a/fortune-teller-ui/src/main/java/io/spring/cloud/samples/fortuneteller/ui/services/fortunes/FortunesClient.java
+++ b/fortune-teller-ui/src/main/java/io/spring/cloud/samples/fortuneteller/ui/services/fortunes/FortunesClient.java
@@ -1,0 +1,15 @@
+package io.spring.cloud.samples.fortuneteller.ui.services.fortunes;
+
+import org.springframework.cloud.netflix.feign.FeignClient;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+
+/**
+ * Created by mszarlinski on 2015-12-03.
+ */
+@FeignClient("fortunes")
+public interface FortunesClient {
+
+    @RequestMapping(value = "/random", method = RequestMethod.GET)
+    Fortune randomFortune();
+}


### PR DESCRIPTION
Example of how to setup and use Feign clients instead of plain RestTemplate.
