### PR TITLE
URL Cleanup

### DIFF
--- a/fortune-teller-ui/src/main/java/io/spring/cloud/samples/fortuneteller/ui/services/fortunes/FortuneService.java
+++ b/fortune-teller-ui/src/main/java/io/spring/cloud/samples/fortuneteller/ui/services/fortunes/FortuneService.java
@@ -18,7 +18,7 @@ public class FortuneService {
 
     @HystrixCommand(fallbackMethod = "fallbackFortune")
     public Fortune randomFortune() {
-        return restTemplate.getForObject("http://fortunes/random", Fortune.class);
+        return restTemplate.getForObject("https://fortunes/random", Fortune.class);
     }
 
     private Fortune fallbackFortune() {


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://fortunes/random (UnknownHostException) with 1 occurrences migrated to:  
  https://fortunes/random ([https](https://fortunes/random) result UnknownHostException).

# Ignored
These URLs were intentionally ignored.

* http://127.0.0.1:8761/eureka/ with 1 occurrences
* http://localhost:7979/hystrix/ with 1 occurrences
* http://localhost:8081/ with 1 occurrences
* http://localhost:8081/hystrix.stream with 1 occurrences
* http://localhost:8888 with 2 occurrences