### PR TITLE
URL Cleanup

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -63,8 +63,8 @@ This will push a Spring Cloud Config Server, a Eureka server, and a Hystrix Dash
 . Edit `scripts/create_services.sh` to add the random routes that were generated for you:
 +
 ----
-cf cups config-server -p '{"uri":"http://config-server-fluxional-suttee.cfapps.io"}'
-cf cups service-registry -p '{"uri":"http://eureka-unprevalent-toper.cfapps.io"}'
+cf cups config-server -p '{"uri":"https://config-server-fluxional-suttee.cfapps.io"}'
+cf cups service-registry -p '{"uri":"https://eureka-unprevalent-toper.cfapps.io"}'
 cf cs elephantsql turtle fortunes-db
 ----
 

--- a/configuration/application.yml
+++ b/configuration/application.yml
@@ -28,7 +28,7 @@ server:
 eureka:
   client:
     serviceUrl:
-      defaultZone: http://eureka.192.168.11.11.xip.io/eureka/
+      defaultZone: https://eureka.192.168.11.11.xip.io/eureka/
   instance:
     metadataMap:
       instanceId: ${instance.guid}:${spring.application.name}:${server.port:8080}


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://eureka.192.168.11.11.xip.io/eureka/ (ConnectTimeoutException) with 1 occurrences migrated to:  
  https://eureka.192.168.11.11.xip.io/eureka/ ([https](https://eureka.192.168.11.11.xip.io/eureka/) result ConnectTimeoutException).
* [ ] http://config-server-fluxional-suttee.cfapps.io (404) with 1 occurrences migrated to:  
  https://config-server-fluxional-suttee.cfapps.io ([https](https://config-server-fluxional-suttee.cfapps.io) result 404).
* [ ] http://eureka-unprevalent-toper.cfapps.io (404) with 1 occurrences migrated to:  
  https://eureka-unprevalent-toper.cfapps.io ([https](https://eureka-unprevalent-toper.cfapps.io) result 404).

# Ignored
These URLs were intentionally ignored.

* http://127.0.0.1:8761 with 1 occurrences
* http://fortunes/random with 1 occurrences
* http://localhost:8888 with 2 occurrences